### PR TITLE
provide a link to a how to guide for the looping video tool

### DIFF
--- a/src/embeds/looping-video.html
+++ b/src/embeds/looping-video.html
@@ -18,6 +18,12 @@
             "tip": "Should be used for muted video footage that adds an extra textural element",
             "fields": [
                 {
+                    "name": "Help",
+                    "type": "howto",
+                    "default": "https://docs.google.com/document/d/1j8bYissxODxR-vDuRgMoLfEoMMVs3nkwHyYd42mJSQ0/edit?usp=sharing",
+                    "text": "How to use this Tool"
+                },
+                {
                     "name": "Poster Image",
                     "type": "text",
                     "default": "https://interactive.guim.co.uk/atoms/2019/02/cactus-thief/v/1550684492149/assets/video.jpg",

--- a/src/tool/embed.html
+++ b/src/tool/embed.html
@@ -195,6 +195,11 @@
             color: #676767;
         }
 
+        .options__howto {
+            font-family: 'Guardian Agate Sans';
+            font-weight: normal;
+        }
+
         .options__input {
             box-sizing: border-box;
             width: 100%;
@@ -424,7 +429,7 @@
 
                         {{#switch type}}
                             {{# case 'howto'}}
-                                <a href='{{ default }}' target="_blank" rel="noopener noreferrer">{{ text }}</a>
+                                <a href='{{ default }}' class="options__howto" target="_blank" rel="noopener noreferrer">{{ text }}</a>
                             {{/case}}
 
                             {{#case 'text'}}

--- a/src/tool/embed.html
+++ b/src/tool/embed.html
@@ -423,6 +423,10 @@
                         {{/if}}
 
                         {{#switch type}}
+                            {{# case 'howto'}}
+                                <a href='{{ default }}' target="_blank" rel="noopener noreferrer">{{ text }}</a>
+                            {{/case}}
+
                             {{#case 'text'}}
                                 <input class='options__input' type='text' value='{{ default }}' name='{{ handlise name }}'>
                             {{/case}}


### PR DESCRIPTION
# Why
It isn't immediately obvious how to go from a video file on your hard drive to a URL.

This change adds a link to [this doc](https://docs.google.com/document/d/1j8bYissxODxR-vDuRgMoLfEoMMVs3nkwHyYd42mJSQ0/edit#) which is a basic how to for the looping video Tool.

# How
Creates a new `help` field type which adds an `a` onto the page. It's generic so, if needed, other Tools can link to a how to guide too.

# Screenshot(s)
![image](https://user-images.githubusercontent.com/836140/75535586-203a7c80-5a0d-11ea-85f3-84e65abb2b95.png)

